### PR TITLE
Mainpage products

### DIFF
--- a/_includes/_pages/index.html
+++ b/_includes/_pages/index.html
@@ -5,24 +5,30 @@
       <!-- Three columns of text below the carousel -->
       <div class="row">
           <div class="col-lg-4">
-              <img src="{{ site.baseurl | append: '/images/senseBox_home_circle_500.png' }}" alt="Generic placeholder image" width="250px" height="250px">
+            <a href="{{ site.baseurl | append: "/" | append: page.lang | append: "/products" }}" class="hero-product">
               <h2>senseBox:home</h2>
+              <img src="{{ site.baseurl | append: '/images/senseBox_home_circle_500.png' }}" alt="senseBox:home" class="hero-product-img">
               <p>{{ t.home_info }}</p>
               <p><a class="btn" href="{{ site.baseurl | append: "/" | append: page.lang | append: "/products" }}" role="button">{{ t.further-infos}} &raquo;</a></p>
+            </a>
           </div>
           <!-- /.col-lg-4 -->
           <div class="col-lg-4">
-            <img src="{{ site.baseurl | append: '/images/senseBox_edu_500.png' }}" width=250px height=250px alt="Generic placeholder image" >
+            <a href="{{ site.baseurl | append: "/" | append: page.lang | append: "/products" }}" class="hero-product">
               <h2>senseBox:edu</h2>
+              <img src="{{ site.baseurl | append: '/images/senseBox_edu_500.png' }}" alt="senseBox:edu" class="hero-product-img">
               <p>{{ t.edu_info }}</p>
               <p><a class="btn" href="{{ site.baseurl | append: "/" | append: page.lang | append: "/products" }}" role="button">{{ t.further-infos}} &raquo;</a></p>
+            </a>
           </div>
           <!-- /.col-lg-4 -->
           <div class="col-lg-4">
-            <img src="{{ site.baseurl | append: '/images/osem_laptop_500.png' }}" width=250px height=250px alt="Generic placeholder image" />
+            <a href="{{ site.baseurl | append: "/" | append: page.lang | append: "/osem" }}" class="hero-product">
               <h2>openSenseMap</h2>
+              <img src="{{ site.baseurl | append: '/images/osem_laptop_500.png' }}" alt="openSenseMap" class="hero-product-img"/>
               <p>{{ t.osem_info }}</p>
               <p><a class="btn" href="{{ site.baseurl | append: "/" | append: page.lang | append: "/osem" }}" role="button">{{ t.further-infos}} &raquo;</a></p>
+            </a>
           </div>
           <!-- /.col-lg-4 -->
       </div>

--- a/_includes/_pages/index.html
+++ b/_includes/_pages/index.html
@@ -9,7 +9,7 @@
               <h2>senseBox:home</h2>
               <img src="{{ site.baseurl | append: '/images/senseBox_home_circle_500.png' }}" alt="senseBox:home" class="hero-product-img">
               <p>{{ t.home_info }}</p>
-              <p><a class="btn" href="{{ site.baseurl | append: "/" | append: page.lang | append: "/products" }}" role="button">{{ t.further-infos}} &raquo;</a></p>
+              <p><button class="btn" href="{{ site.baseurl | append: "/" | append: page.lang | append: "/products" }}" role="button" type="button">{{ t.further-infos}} &raquo;</button></p>
             </a>
           </div>
           <!-- /.col-lg-4 -->
@@ -18,7 +18,7 @@
               <h2>senseBox:edu</h2>
               <img src="{{ site.baseurl | append: '/images/senseBox_edu_500.png' }}" alt="senseBox:edu" class="hero-product-img">
               <p>{{ t.edu_info }}</p>
-              <p><a class="btn" href="{{ site.baseurl | append: "/" | append: page.lang | append: "/products" }}" role="button">{{ t.further-infos}} &raquo;</a></p>
+              <p><button class="btn" href="{{ site.baseurl | append: "/" | append: page.lang | append: "/products" }}" role="button" type="button">{{ t.further-infos}} &raquo;</button></p>
             </a>
           </div>
           <!-- /.col-lg-4 -->
@@ -27,7 +27,7 @@
               <h2>openSenseMap</h2>
               <img src="{{ site.baseurl | append: '/images/osem_laptop_500.png' }}" alt="openSenseMap" class="hero-product-img"/>
               <p>{{ t.osem_info }}</p>
-              <p><a class="btn" href="{{ site.baseurl | append: "/" | append: page.lang | append: "/osem" }}" role="button">{{ t.further-infos}} &raquo;</a></p>
+              <p><button class="btn" href="{{ site.baseurl | append: "/" | append: page.lang | append: "/osem" }}" role="button" type="button">{{ t.further-infos}} &raquo;</button></p>
             </a>
           </div>
           <!-- /.col-lg-4 -->

--- a/_sass/_sensebox.scss
+++ b/_sass/_sensebox.scss
@@ -991,6 +991,21 @@ $carousel-height: 450px;
     margin-left: 10px;
 }
 
+.marketing .col-lg-4 {
+  .hero-product {
+    color: $text-color;
+    &:hover {
+      text-decoration: none;
+      color: $text-color;
+    }
+  }
+  .hero-product-img {
+    max-width: 250px;
+    max-height: 250px;
+  }
+}
+
+
 .badges {
     text-align: center;
     margin-top: 5em;

--- a/_sass/_sensebox.scss
+++ b/_sass/_sensebox.scss
@@ -1000,8 +1000,9 @@ $carousel-height: 450px;
     }
   }
   .hero-product-img {
-    max-width: 250px;
-    max-height: 250px;
+    max-width: 230px;
+    max-height: 230px;
+    margin-bottom: 10px;
   }
 }
 


### PR DESCRIPTION
This pull request moves the headline of the products on the main page above the image. @felixerdy @robarto @mpfeil 
![mainpage](https://cloud.githubusercontent.com/assets/1494211/26238595/0e2e1a0a-3c7a-11e7-8db9-f277ef0d493e.gif)
