### PR TITLE
new events layout

### DIFF
--- a/_includes/_pages/index.html
+++ b/_includes/_pages/index.html
@@ -62,8 +62,8 @@
         <p><a class="btn" href="{{ site.url | append: "/blog" }}" role="button">{{ t.go-to-blog }} &raquo;</a></p>
       </div>
       <hr />
-      <h1>{{ t.upcoming_events }}</h1>
-      <div class="container">
+      <h1 style="text-align: center;">{{ t.upcoming_events }}</h1>
+      <div class="row">
         {% assign events = site.events | sort: 'ending-date' %}
         {% for event in events %}
           {% capture nowunix %}{{'now' | date: '%s'}}{% endcapture %}

--- a/_includes/event_template.html
+++ b/_includes/event_template.html
@@ -1,17 +1,9 @@
-<div class="event thumbnail">
-  <div>
-    <h3 class="no-margin">
-      {{ include.event.starting-date | date: '%d.%m.' }}
-      <br />
-      {{ include.event.starting-date | date: '%Y' }}
-    </h3>
-  </div>
-  <div class="details">
-    <p class="no-margin">
-      <b>{{ include.event.title }}</b>
-    </p>
-    <p class="no-margin">
-      {{ include.event.place }}
-    </p>
+<div class="col-sm-4 col-md-4 col-lg-4">
+  <div class="thumbnail">
+    <div class="caption">
+      <p>{{ include.event.starting-date | date: '%d.%m.%Y' }}</p>
+      <h3>{{ include.event.title }}</h3>
+      <p>{{ include.event.place }}</p>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
Changed layout for events on landing page.

![events](https://user-images.githubusercontent.com/2471172/27853517-4215de8a-6163-11e7-9f7b-c865df9c6766.png)

Maybe we can make events clickable and have a short description for each event.