### PR TITLE
fix wrong language tag in project

### DIFF
--- a/_projects/de/2019-03-01-AkustischerSchalter.md
+++ b/_projects/de/2019-03-01-AkustischerSchalter.md
@@ -6,7 +6,7 @@ author: Benni
 abstract: "Mithilfe des Mikrofons lässt sich ein akustischer Schalter bauen"
 image: IntelligenterLichtschalterKlein.png
 image1: /images/projects/IntelligenterLichtschalterKlein.png
-lang: en
+lang: de
 material:
     - Mic-Breakout
     - 1x LED


### PR DESCRIPTION
language tag in "Akustischer Lichtschalter" was set incorrectly to "en" instead of "de"